### PR TITLE
Implement `Base.hash`

### DIFF
--- a/src/MultiplesOfPi.jl
+++ b/src/MultiplesOfPi.jl
@@ -88,6 +88,13 @@ end
 Base.:(==)(p::PiExpTimes, x::Real) = p == PiExpTimes(x, 0)
 Base.:(==)(x::Real, p::PiExpTimes) = p == x
 
+function Base.hash(p::PiExpTimes, h::UInt)
+    iszero(p) && return hash(0, h)
+    iszero(p.n) && return hash(p.x, h)
+    p == Pi && return hash(pi, h)
+    return hash(p.x, hash(p.n, hash(:PiExpTimes, h)))
+end
+
 simplify(p) = p
 simplify(p::PiExpTimes{Irrational{:π}}) = PiExpTimes(1, p.n + one(p.n))
 simplify(p::PiExpTimes{<:PiExpTimes}) = simplify(p.x) * Pi^(p.n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,6 +124,14 @@ end
     end
 end
 
+@testset "hash" begin
+    @test hash(0 * Pi) == hash(0)
+    @test hash(Pi) == hash(pi)
+    @test hash(PiExpTimes(3, 0)) == hash(3)
+    @test hash(4 * Pi ^ 2) == hash((2 * Pi) ^ 2)
+    @test unique(Any[pi, Pi, 0, 0 * pi, 3.0, 3 * Pi ^ 0]) == Any[pi, 0, 3]
+end
+
 @testset "sign" begin
     @testset "PiExpTimes" begin
         @testset "sign" begin


### PR DESCRIPTION
Without this, the following code results in a `MethodError`:

```julia
julia> unique([Pi])
```

I've made sure that `Pi` and `0 * Pi` hash to the same values as their equivalents, since (quoting the `isequal` docstring)

> `isequal(x,y)` must imply that `hash(x) == hash(y)`.

UPDATE: I've also done the same thing when `n == 0`.