### PR TITLE
Promote `pi` to `PiExpTimes`

### DIFF
--- a/src/MultiplesOfPi.jl
+++ b/src/MultiplesOfPi.jl
@@ -230,6 +230,8 @@ function Base.:(/)(p1::PiExpTimes, p2::PiExpTimes)
 	PiExpTimes(p1.x/p2.x, p1.n-p2.n)
 end
 
+Base.convert(::Type{T}, ::Irrational{:π}) where {T<:PiExpTimes} = convert(T, Pi)
+
 for f in [:(+), :(-), :(*), :(/)]
 	@eval Base.$f(p::PiExpTimes, ::Irrational{:π}) = $f(p, Pi)
 	@eval Base.$f(::Irrational{:π}, p::PiExpTimes) = $f(Pi, p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,8 @@ end
         @test PiExpTimes{Real}(π).x === 1
 
         @test PiExpTimes{Irrational{:π}}(π, 2) == PiExpTimes(1, 3)
+
+        @test convert(typeof(Pi), pi) === Pi
     end
 
     @test PiExpTimes(1, -1) ≈ 1/π


### PR DESCRIPTION
Fix #11 

After this,
```julia
julia> [Pi, pi]
2-element Vector{PiExpTimes{Int64, Int64}}:
 Pi
 Pi
```