### PR TITLE
README: Use tables for side-by-side comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,27 @@ The number `π` is represented as an `Irrational` type in julia, and may be comp
 
 Delaying the conversion of `π` to a float results in precise mathematical expressions such as
 
-```julia
-julia> (1//3)π + (4//3)π == (5//3)π
-false
-
-julia> (1//3)Pi + (4//3)Pi == (5//3)Pi
-true
-
-julia> float(sqrt(pi)^2) == float(pi)
-false
-
-julia> float(sqrt(Pi)^2) == float(Pi)
-true
-```
+<table>
+<tr><th>Using <code>π</code></th><th>Using <code>Pi</code></th></tr>
+<tr><td>
+  
+  ```julia
+  julia> (1//3)π + (4//3)π == (5//3)π
+  false
+  
+  julia> float(sqrt(pi)^2) == float(pi)
+  false
+  ```
+</td><td>
+  
+  ```julia
+  julia> (1//3)Pi + (4//3)Pi == (5//3)Pi
+  true
+  
+  julia> float(sqrt(Pi)^2) == float(Pi)
+  true
+  ```
+</td></tr></table>
 
 We may also simplify algebraic expressions involving powers of `Pi` as
 
@@ -58,54 +66,83 @@ Pi^0 + Pi^0*im
 
 The type `PiTimes` uses `sinpi` and `cospi` under the hood when it is used as an argument to `sin` and `cos`. This results in exact results in several contexts where the inaccuracies arise from floating-point conversions.
 
-```julia
-julia> cos(3π/2)
--1.8369701987210297e-16
-
-julia> cos(3Pi/2)
-0.0
-
-julia> sin(-π)
--1.2246467991473532e-16
-
-julia> sin(-Pi)
--0.0
-
-julia> tan(π/2)
-1.633123935319537e16
-
-julia> tan(Pi/2)
-Inf
-```
+<table>
+<tr><th>Using <code>π</code></th><th>Using <code>Pi</code></th></tr>
+<tr><td>
+  
+  ```julia
+  julia> cos(3π/2)
+  -1.8369701987210297e-16
+  
+  julia> sin(-π)
+  -1.2246467991473532e-16
+  
+  julia> tan(π/2)
+  1.633123935319537e16
+  ```
+</td><td>
+  
+  ```julia
+  julia> cos(3Pi/2)
+  0.0
+  
+  julia> sin(-Pi)
+  -0.0
+  
+  julia> tan(Pi/2)
+  Inf
+  ```
+</td></tr></table>
 
 We may compute complex exponential exactly:
 
-```julia
-julia> exp(im*π/2)
-6.123233995736766e-17 + 1.0im
+<table>
+<tr><th>Using <code>π</code></th><th>Using <code>Pi</code></th></tr>
+<tr><td>
+  
+  ```julia
+  julia> exp(im*π/2)
+  6.123233995736766e-17 + 1.0im
+  
+  # Euler's identity : exp(iπ) + 1 == 0
+  julia> exp(im*π) + 1
+  0.0 + 1.2246467991473532e-16im
+  ```
+</td><td>
+  
+  ```julia
+  julia> exp(im*Pi/2)
+  0.0 + 1.0im
+  
+  # Euler's identity : exp(iπ) + 1 == 0
+  julia> exp(im*Pi) + 1
+  0.0 + 0.0im
+  ```
 
-julia> exp(im*Pi/2)
-0.0 + 1.0im
-
-# Euler's identity : exp(iπ) + 1 == 0
-julia> exp(im*π) + 1
-0.0 + 1.2246467991473532e-16im
-
-julia> exp(im*Pi) + 1
-0.0 + 0.0im
-```
+</td></tr></table>
 
 Hyperbolic functions work as expected:
 
-```julia
-# cosh(ix) = cos(x)
-# Should be exactly zero for x = π/2
-julia> cosh(im*π/2)
-6.123233995736766e-17 + 0.0im
+<table>
+<tr><th>Using <code>π</code></th><th>Using <code>Pi</code></th></tr>
+<tr><td>
+  
+  ```julia
+  # cosh(ix) = cos(x)
+  # Should be exactly zero for x = π/2
+  julia> cosh(im*π/2)
+  6.123233995736766e-17 + 0.0im
+  ```
+</td><td>
+  
+  ```julia
+  # cosh(ix) = cos(x)
+  # Should be exactly zero for x = π/2
+  julia> cosh(im*Pi/2)
+  0.0 + 0.0im
+  ```
 
-julia> cosh(im*Pi/2)
-0.0 + 0.0im
-```
+</td></tr></table>
 
 ### Interactions with π
 


### PR DESCRIPTION
I think side-by-side comparisons can help make the case for using this package more directly and emphatically than sequential code blocks. The markdown+HTML syntax gets a little more complex, but it's still relatively readable IMO, so it seems worth the trade-off.

For visual comparison: [before](https://github.com/jishnub/MultiplesOfPi.jl/blob/27cd0683e63e2a64efadf080b555223330bf51e7/README.md), [after](https://github.com/waldyrious/MultiplesOfPi.jl/blob/02a28c5dd305e390fea187f269432bf4b2e18946/README.md).

Adding a couple screenshots below, for convenience.

Before:
![before screenshot](https://github.com/jishnub/MultiplesOfPi.jl/assets/478237/ef33302e-cc87-42bc-b40b-533a302898ff)

After:
![after screenshot](https://github.com/jishnub/MultiplesOfPi.jl/assets/478237/caa6b05d-0347-4561-8eb5-8bc0698f8780)
